### PR TITLE
Upgrade the version of terraform-aws-lambda.

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/claranet/terraform-aws-lambda?ref=v0.5.0"
+  source = "github.com/claranet/terraform-aws-lambda?ref=v0.8.2"
 
   function_name = "${var.name}"
   description   = "Manages ASG instance replacement"


### PR DESCRIPTION
Upgrading the version of terraform-aws-lambda that
terraform-aws-asg-instance-replacement is using as I am hitting an error
that was fixed in terraform-aws-lambda a while ago (Python version
problems).