### PR TITLE
Update lambda sub-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It sets old instances as unhealthy one at a time to gradually replace them with 
 
 It waits for new instances to be completely healthy, ready and in service before proceeding to replace more instances. It will wait for ASG lifecycle hooks and Target Group health checks if they are being used.
 
+## Important
+
+Version `v1.0.0` of this module and above are not compatible with Terraform versions < `0.12.0`.  For earlier Terraform versions please use `v0.x.x` releases.
+
 ## Caution
 
 __Use this module with caution; it terminates healthy instances.__

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/claranet/terraform-aws-lambda?ref=v0.12.0"
+  source = "github.com/claranet/terraform-aws-lambda?ref=v1.1.0"
 
   function_name = "${var.name}"
   description   = "Manages ASG instance replacement"
@@ -10,8 +10,9 @@ module "lambda" {
 
   source_path = "${path.module}/lambda"
 
-  attach_policy = true
-  policy        = "${data.aws_iam_policy_document.lambda.json}"
+  policy = {
+    json = "${data.aws_iam_policy_document.lambda.json}"
+  }
 }
 
 data "aws_iam_policy_document" "lambda" {


### PR DESCRIPTION
Using this module with Terraform 0.12.10 causes a few errors due to the terraform-aws-lambda sub-module

The Lambda submodule is already fixed, so I have updated the referenced version from v0.12.0 to v1.1.0

Due to some minor changes in the parameters for the Lambda module I have:
- removed the `attach_policy` parameter
- modified the `policy` parameter to follow the new parameter style