### PR TITLE
Allow changing of python version

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -4,7 +4,7 @@ module "lambda" {
   function_name = var.name
   description   = "Manages ASG instance replacement"
   handler       = "main.lambda_handler"
-  runtime       = "python3.6"
+  runtime       = var.python_version
   layers        = var.lambda_layers
   timeout       = var.timeout
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,9 @@ variable "lambda_layers" {
   description = "List of Lambda Layer Version ARNs to attach to the Lambda Function"
   default     = []
 }
+
+variable "python_version" {
+  type        = string
+  description = "Specify the Python version to be used"
+  default     = "python3.9"
+}


### PR DESCRIPTION
Allow changing of python version as the current specified version of Python is not supported by AWS anymore